### PR TITLE
Improve generated code to not use dynamic casting

### DIFF
--- a/support/font-templates/font/flutter_iconset.tpl
+++ b/support/font-templates/font/flutter_iconset.tpl
@@ -23,7 +23,7 @@ class ${font.fontname} {
   ${font.fontname}._();
 
   static const _kFontFam = '${font.familyname}';
-  static const _kFontPkg = null;
+  static const String _kFontPkg = null;
 <% glyphs.forEach(function(glyph) { %>
   static const IconData ${glyph.dart} = IconData(0x${glyph.code16}, fontFamily: _kFontFam, fontPackage: _kFontPkg);<% }); %>
 }


### PR DESCRIPTION
Current generated class use dynamic type as default for generated code, I believe that it can improve by removing this dynamic implicit casting from the code itself.

If you set in `analysis_options.yaml`:

```yaml
analyzer:
    strong-mode:
        implicit-dynamic: false
```

Then the generated icons class contains multiple errors:

1.
![image](https://user-images.githubusercontent.com/76348/101995981-6b700400-3c9c-11eb-9b1a-fe9dcfdcee51.png)

2.
![image](https://user-images.githubusercontent.com/76348/101995983-6dd25e00-3c9c-11eb-9403-48c2479bac87.png)


You can remove this file from the analysis with this setup:

```yaml
analyzer:
  exclude:
    - your_icons_file.dart
```

But still is something there that could be improved, this PR try to improve the generated class just by defining its type, so the variable type is not dynamic and all is type safe.

Im not sure if this fix will do the job, since there are no tests, can you drive me into what is missing?