### PR TITLE
Changed os.tempDir() to os.tempdir()

### DIFF
--- a/internal/fontello/font_build/font_build.js
+++ b/internal/fontello/font_build/font_build.js
@@ -72,7 +72,7 @@ module.exports = function (N, apiPath) {
       clientConfig: data.config,
       builderConfig,
       cwdDir: N.mainApp.root,
-      tmpDir: path.join(os.tmpDir(), 'flutter-icons', `flutter-icons-${data.fontId.substr(0, 8)}`),
+      tmpDir: path.join(os.tmpdir(), 'flutter-icons', `flutter-icons-${data.fontId.substr(0, 8)}`),
       timestamp: Date.now(),
       result: null,
       logger


### PR DESCRIPTION
I tried this with node  v14.17.0 after downloading I got os.tempDir() is not a function after finding at stack overflow i made this minor change and app worked without an error.
Thank you.
[stackoverflow.com/questions/62163677/why-does-calling-os-tmpdir-produce-an-error-on-only-some-machines](stackoverflow)